### PR TITLE
Modified check in _parse to accept relative URI

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -196,13 +196,13 @@ L.GPX = L.FeatureGroup.extend({
       _this.addLayer(layers);
       _this.fire('loaded');
     }
-    if (input.indexOf('http') === 0) {
-      this._load_xml(input, cb, options, async);
-    } else {
+    if (input.substr(0)==='<') { // direct XML has to start with a <
       var parser = new DOMParser();
       setTimeout(function() {
         cb(parser.parseFromString(input, "text/xml"), options);
       });
+    } else {
+      this._load_xml(input, cb, options, async);
     }
   },
 


### PR DESCRIPTION
When using a path like '/tracks/current.gpx' the new check from #4 did expect it to be XML data but instead the data needs to be loaded with _load_xml. XML Data has to start with a lower than character now.
