### PR TITLE
Improve Empty TrackSegment Tolerance

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -219,6 +219,7 @@ L.GPX = L.FeatureGroup.extend({
       el = xml.getElementsByTagName(tags[j][0]);
       for (i = 0; i < el.length; i++) {
         var coords = this._parse_trkseg(el[i], xml, options, tags[j][1]);
+        if (coords.length === 0) continue;
 
         // add track
         var l = new L.Polyline(coords, options.polyline_options);


### PR DESCRIPTION
I had problems with some GPX-Files. The problem was that `this._parse_trkseg` returned an empty array, which is because it checks `if (!el.length) return [];` (line 258). Leaflet itself throws an error for the following `L.Marker(coords[0]` calls. That is, this loop should stop there and continue if we get an empty array from `this._parse_trkseg`.
