### PR TITLE
Possibility to disable the start and end icon

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -226,21 +226,25 @@ L.GPX = L.FeatureGroup.extend({
         this.fire('addline', { line: l })
         layers.push(l);
 
-        // add start pin
-        var p = new L.Marker(coords[0], {
-          clickable: false,
-            icon: new L.GPXTrackIcon({iconUrl: options.marker_options.startIconUrl})
-        });
-        this.fire('addpoint', { point: p });
-        layers.push(p);
+        if (options.marker_options.startIconUrl) {
+          // add start pin
+          var p = new L.Marker(coords[0], {
+            clickable: false,
+              icon: new L.GPXTrackIcon({iconUrl: options.marker_options.startIconUrl})
+          });
+          this.fire('addpoint', { point: p });
+          layers.push(p);
+        }
 
-        // add end pin
-        p = new L.Marker(coords[coords.length-1], {
-          clickable: false,
-          icon: new L.GPXTrackIcon({iconUrl: options.marker_options.endIconUrl})
-        });
-        this.fire('addpoint', { point: p });
-        layers.push(p);
+        if (options.marker_options.endIconUrl) {
+          // add end pin
+          p = new L.Marker(coords[coords.length-1], {
+            clickable: false,
+            icon: new L.GPXTrackIcon({iconUrl: options.marker_options.endIconUrl})
+          });
+          this.fire('addpoint', { point: p });
+          layers.push(p);
+        }
       }
     }
 


### PR DESCRIPTION
I needed the possibility to disable the end icon of a gpx file. This can be useful if the start and the end of the gpx file are the same. Also it would be nice to disable also the start icon if not needed.

With the change, you can overwrite the startIconUrl and endIconUrl with null, so no marker is shown:

marker_options: {
    startIconUrl: null,
    endIconUrl: null,
}

I added only an if statement around the marker code.

It would be cool, if you can merge the change.
