### PR TITLE
let _parse accept XMLDocument, too

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -204,7 +204,11 @@ L.GPX = L.FeatureGroup.extend({
       _this.addLayer(layers);
       _this.fire('loaded');
     }
-    if (input.substr(0,1)==='<') { // direct XML has to start with a <
+    if (input instanceof XMLDocument) {
+      setTimeout(function() {
+        cb(input, options);
+      });
+    } else if (typeof input.substr === 'function' && input.substr(0,1)==='<') { // direct XML has to start with a <
       var parser = new DOMParser();
       setTimeout(function() {
         cb(parser.parseFromString(input, "text/xml"), options);


### PR DESCRIPTION
Hi,

I've made a simple change to let L.GPX._parse accept XMLDocument object, too.  Can you please check?  Thanks.

-Attila
