### PR TITLE
Add option to select parsed GPX elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ new L.GPX(gpx, {async: true}).on('loaded', function(e) {
 }).addTo(map);
 ```
 
+You can change the GPX track's appearance with a `polyline_options` object in
+the second argument of the constructor. Available options are listed in the
+[Leaflet documentation](http://leafletjs.com/reference.html#polyline).
+
+Some GPX tracks contain the actual route/track twice, both the `<trk>` and
+`<rte>` elements are used. You can tell `leaflet-gpx` which tag to use or to
+use both (which is the default setting for backwards compatibility) with the
+`gpx_options` object in the second argument of the constructor. The member
+`parseElements` controls this behavior, it should be an array that contains
+`'route'` and/or `'track'`.
+
+
 If you want to display additional information about the GPX track, you can do
 so in the 'loaded' event handler, calling one of the following methods on the
 `GPX` object `e.target`:

--- a/gpx.js
+++ b/gpx.js
@@ -53,6 +53,9 @@ var _DEFAULT_MARKER_OPTS = {
 var _DEFAULT_POLYLINE_OPTS = {
 	color:'blue'
 };
+var _DEFAULT_GPX_OPTS = {
+  parseElements: ['track', 'route']
+};
 L.GPX = L.FeatureGroup.extend({
   initialize: function(gpx, options) {
     options.max_point_interval = options.max_point_interval || _MAX_POINT_INTERVAL_MS;
@@ -62,6 +65,9 @@ L.GPX = L.FeatureGroup.extend({
     options.polyline_options = this._merge_objs(
       _DEFAULT_POLYLINE_OPTS,
       options.polyline_options || {});
+    options.gpx_options = this._merge_objs(
+      _DEFAULT_GPX_OPTS,
+      options.gpx_options || {});
 
     L.Util.setOptions(this, options);
 
@@ -220,7 +226,14 @@ L.GPX = L.FeatureGroup.extend({
 
   _parse_gpx_data: function(xml, options) {
     var j, i, el, layers = [];
-    var tags = [['rte','rtept'], ['trkseg','trkpt']];
+    var tags = [];
+    var parseElements = options.gpx_options.parseElements;
+    if(parseElements.indexOf('route') > -1) {
+      tags.push(['rte','rtept']);
+    }
+    if(parseElements.indexOf('track') > -1) {
+      tags.push(['trkseg','trkpt']);
+    }
 
     var name = xml.getElementsByTagName('name');
     if (name.length > 0) {


### PR DESCRIPTION
There are (broken?) GPX tracks which contain the actual route/track
twice, both GPX elements are used. This change allows `gpx-leaflet` to
parse only the desired part of the GPX file. The default is to parse
both, to preserve the former behavior.

cf. #21 