### PR TITLE
PR for issue #23: Parse Waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,34 @@ new L.GPX(url, {
   map.fitBounds(e.target.getBounds());
 }).addTo(map);
 ```
+About waypoints
+---------------
+
+By default `gpx.js` will parse Waypoints from a GPX file. This may also be steered via the value `waypoint` in `gpx_options`, e.g. `parseElements: ['track', 'route', 'waypoint']`. 
+
+Waypoint icons: by default the Leaflet default icon is shown for each waypoint. Via the `L.GPX` constructor option: `marker_options.wptIconUrls` one can supply mappings from the Waypoint "SYM" name to a user-supplied icon file or URL. See the example below.
+
+```javascript
+
+new L.GPX(app.params.gpx_url, {
+    async: true,
+    marker_options: {
+		.
+		.
+        wptIconUrls: {
+            'Geocache Found': 'img/gpx/geocache.png',
+            'Park': 'img/gpx/tree.png'
+        },
+		.
+		.
+        shadowUrl: 'http://github.com/mpetazzoni/leaflet-gpx/raw/master/pin-shadow.png'
+    }
+}).on('loaded', function (e) {
+        var gpx = e.target;
+        map.fitBounds(gpx.getBounds());
+    }).addTo(map);
+}
+```
 
 Caveats
 -------


### PR DESCRIPTION
This PR adds parsing Waypoints in a GPX file as requested via issue #23. These are shown as Leaflet Default markers. Optionally a mapping can be supplied between WPT Symbols (SYM element) and user-provided icons. See the README how to do this. See an example here:
http://app.map5.nl/nltopo/?gpx=gpx/vliegenbos238.gpx for this GPX file: http://app.map5.nl/nltopo/gpx/vliegenbos238.gpx