### PR TITLE
Calculate days in duration

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -42,6 +42,7 @@ var _MAX_POINT_INTERVAL_MS = 15000;
 var _SECOND_IN_MILLIS = 1000;
 var _MINUTE_IN_MILLIS = 60 * _SECOND_IN_MILLIS;
 var _HOUR_IN_MILLIS = 60 * _MINUTE_IN_MILLIS;
+var _DAY_IN_MILLIS = 24 * _HOUR_IN_MILLIS;
 
 var _DEFAULT_MARKER_OPTS = {
   startIconUrl: 'pin-icon-start.png',
@@ -95,6 +96,11 @@ L.GPX = L.FeatureGroup.extend({
 
   get_duration_string: function(duration, hidems) {
     var s = '';
+
+    if (duration >= _DAY_IN_MILLIS) {
+      s += Math.floor(duration / _DAY_IN_MILLIS) + 'd ';
+      duration = duration % _DAY_IN_MILLIS;
+    }
 
     if (duration >= _HOUR_IN_MILLIS) {
       s += Math.floor(duration / _HOUR_IN_MILLIS) + ':';


### PR DESCRIPTION
It is not unusual to have tracks that span more than one day, especially in multi-day hiking trips. This is a suggestion to take days into account so that hours don't end up being ineligible (e.g. you cannot easily make sense of 62 hours when you see it unless you calculate how many days it is).