### PR TITLE
Add labels for named points on route/track

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -403,7 +403,7 @@ L.GPX = L.FeatureGroup.extend({
         if (options.point_label_options && options.point_label_options.regexMatch && options.point_label_options.regexMatch.test(name)) {
           var marker = new L.Marker(ll, {
             icon: L.divIcon({
-              className: 'circle '+options.point_label_options.regexMatch.lassName,
+              className: 'circle '+options.point_label_options.className,
               iconSize: [15, 15],
               html: '<label>' + _[0].textContent + '</label>'
             })

--- a/gpx.js
+++ b/gpx.js
@@ -280,7 +280,7 @@ L.GPX = L.FeatureGroup.extend({
     for (j = 0; j < tags.length; j++) {
       el = xml.getElementsByTagName(tags[j][0]);
       for (i = 0; i < el.length; i++) {
-        var coords = this._parse_trkseg(el[i], xml, options, tags[j][1]);
+        var coords = this._parse_trkseg(el[i], xml, options, tags[j][1], layers);
         if (coords.length === 0) continue;
 
         // add track
@@ -368,7 +368,7 @@ L.GPX = L.FeatureGroup.extend({
     }
   },
 
-  _parse_trkseg: function(line, xml, options, tag) {
+  _parse_trkseg: function(line, xml, options, tag, layers) {
     var el = line.getElementsByTagName(tag);
     if (!el.length) return [];
     var coords = [];
@@ -395,6 +395,22 @@ L.GPX = L.FeatureGroup.extend({
         ll.meta.hr = parseInt(_[0].textContent);
         this._info.hr._points.push([this._info.length, ll.meta.hr]);
         this._info.hr._total += ll.meta.hr;
+      }
+
+      _ = el[i].getElementsByTagName('name');
+      if (_.length > 0) {
+        var name = _[0].textContent;
+        if (options.point_label_options && options.point_label_options.regexMatch && options.point_label_options.regexMatch.test(name)) {
+          var marker = new L.Marker(ll, {
+            icon: L.divIcon({
+              className: 'circle '+options.point_label_options.regexMatch.lassName,
+              iconSize: [15, 15],
+              html: '<label>' + _[0].textContent + '</label>'
+            })
+          });
+          this.fire('addpoint', { point: marker, point_type: 'waypoint' });
+          layers.push(marker);
+        }
       }
 
       if(ll.meta.ele > this._info.elevation.max)


### PR DESCRIPTION
This will allow users to add labels for route/track points which have a `<name></name>` set.

Configure by passing point_label_options

```javascript
var xxx = new L.GPX(url, {
          async: true,
          point_label_options: {
                    regexMatch: /^(POI)/i,
                    className: 'blue'
          }
        }).addTo(map)
```

Example CSS

```css
div.leaflet-marker-icon.circle.blue {
        background-color: blue;
        border-color: blue;
        border-radius: 9px;
        border-style: solid;
        border-width: 1px;
        width: 15px;
        height: 15px;
        opacity: 0.6;
        white-space: nowrap;
}

div.leaflet-marker-icon.circle.blue label {
        position: relative;
        left: 15px;
        top: -15px;
        font-weight: bold;
        text-shadow: 0 0 3px white;
}
```