### PR TITLE
new: added helper method for ISO-like duration representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,15 @@ at your disposal:
 * `get_elevation_loss_imp()`: returns the cumulative elevation loss, in feet
 
 The reason why these methods return milliseconds is that you have at your
-disposal a nice helper method to format a duration in milliseconds into a cool
-string like `3:07'48"` or `59'32.431`:
+disposal nice helper methods to format a duration in milliseconds into a cool
+string:
 
-* `get_duration_string(duration, hidems)`, where `duration` is in
+* `get_duration_string(duration, hidems)` format to a string like `3:07'48"`
+  or `59'32.431`, where `duration` is in
+  milliseconds and `hidems` is an optional boolean you can use to request never
+  to display millisecond precision.
+* `get_duration_string_iso(duration, hidems)` formats to an ISO like 
+  representation like `3:07:48` or `59:32.431`, where `duration` is in
   milliseconds and `hidems` is an optional boolean you can use to request never
   to display millisecond precision.
 

--- a/gpx.js
+++ b/gpx.js
@@ -119,6 +119,11 @@ L.GPX = L.FeatureGroup.extend({
     return s;
   },
 
+  get_duration_string_iso: function(duration, hidems){
+  	var s = this.get_duration_string(duration, hidems);
+	return s.replace("'",':').replace('"','');
+  },
+
   // Public methods
   to_miles:            function(v) { return v / 1.60934; },
   to_ft:               function(v) { return v * 3.28084; },


### PR DESCRIPTION
added a little helper method to represent durations in an ISO-like format, see [wikipedia](https://en.wikipedia.org/wiki/ISO_8601#Durations) for some details.

Maybe the old `get_duration_string`  should be called `get_duration_string_imp`, but this would be a breaking change...