### PR TITLE
Correction when setting the value this._info.duration.start, if there is more than one <trkseg>-segment.

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -488,7 +488,9 @@ L.GPX = L.FeatureGroup.extend({
         this._info.duration.total += t;
         if (t < options.max_point_interval) this._info.duration.moving += t;
       } else {
-        this._info.duration.start = ll.meta.time;
+		if (this._info.duration.start == null) {
+			this._info.duration.start = ll.meta.time;
+		}
       }
 
       last = ll;


### PR DESCRIPTION
If there is more than one `<trkseg>`-segment the value for `this._info.duration.start` is set with the value of the last `<trkseg>`-segment. 
With my little change this value will taken form the start of the first `<trkseg>`-segment.