### PR TITLE
set default value for time

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -448,7 +448,7 @@ L.GPX = L.FeatureGroup.extend({
       if (_.length > 0) {
         ll.meta.ele = parseFloat(_[0].textContent);
       }
-	  
+
       _ = el[i].getElementsByTagNameNS('*', 'hr');
       if (_.length > 0) {
         ll.meta.hr = parseInt(_[0].textContent);

--- a/gpx.js
+++ b/gpx.js
@@ -448,6 +448,7 @@ L.GPX = L.FeatureGroup.extend({
       if (_.length > 0) {
         ll.meta.ele = parseFloat(_[0].textContent);
       }
+	  
       _ = el[i].getElementsByTagNameNS('*', 'hr');
       if (_.length > 0) {
         ll.meta.hr = parseInt(_[0].textContent);

--- a/gpx.js
+++ b/gpx.js
@@ -445,6 +445,8 @@ L.GPX = L.FeatureGroup.extend({
       _ = el[i].getElementsByTagName('ele');
       if (_.length > 0) {
         ll.meta.ele = parseFloat(_[0].textContent);
+      } else {
+        ll.meta.time = new Date('1970-01-01T00:00:00');
       }
 
       _ = el[i].getElementsByTagNameNS('*', 'hr');

--- a/gpx.js
+++ b/gpx.js
@@ -440,15 +440,14 @@ L.GPX = L.FeatureGroup.extend({
       _ = el[i].getElementsByTagName('time');
       if (_.length > 0) {
         ll.meta.time = new Date(Date.parse(_[0].textContent));
+      } else {
+        ll.meta.time = new Date('1970-01-01T00:00:00');
       }
 
       _ = el[i].getElementsByTagName('ele');
       if (_.length > 0) {
         ll.meta.ele = parseFloat(_[0].textContent);
-      } else {
-        ll.meta.time = new Date('1970-01-01T00:00:00');
       }
-
       _ = el[i].getElementsByTagNameNS('*', 'hr');
       if (_.length > 0) {
         ll.meta.hr = parseInt(_[0].textContent);


### PR DESCRIPTION
It happens very often that the `<time>`-tag in the gpx file is removed. Currently this plugin throws an error and terminate. My PR would insert a default value if a `<trkseg>`-tag does not contain a `<time>`-tag.