### PR TITLE
Alternative distance marker version.

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -506,7 +506,7 @@ L.GPX = L.FeatureGroup.extend({
             if (options.gpx_options.show_kilometer_point) {
               if ((parseInt(this._info.length/1000) - this._parse_current_kilometer) > options.gpx_options.kilometer_point_options.kilometer_point_interval-1) {
                 this._parse_current_kilometer = parseInt(this._info.length/1000);
-                var icon = L.divIcon({ className: 'kilometer_tooltip', html: this._parse_current_kilometer.toString(), iconSize: options.gpx_options.mile_point_options.kilometer_point_radius });
+                var icon = L.divIcon({ className: 'kilometer_tooltip', html: this._parse_current_kilometer.toString(), iconSize: options.gpx_options.kilometer_point_options.kilometer_point_radius });
                 var marker = L.marker(ll, { icon: icon });
                 kilometer_point_layers.push(marker);
               }

--- a/gpx.js
+++ b/gpx.js
@@ -65,7 +65,21 @@ var _DEFAULT_POLYLINE_OPTS = {
   color: 'blue'
 };
 var _DEFAULT_GPX_OPTS = {
-  parseElements: ['track', 'route', 'waypoint']
+  parseElements: ['track', 'route', 'waypoint'],
+  show_kilometer_point: false,
+  kilometer_point_options : {
+    kilometer_point_color: 'blue',
+    kilometer_point_color_text: 'white',
+    kilometer_point_interval: 1,
+    kilometer_point_radius: 12,
+  },
+  show_mile_point: true,
+  mile_point_options : {
+    mile_point_color: 'blue',
+    mile_point_color_text: 'white',
+    mile_interval: 1,
+    mile_point_radius: 12,
+  },
 };
 L.GPX = L.FeatureGroup.extend({
   initialize: function(gpx, options) {
@@ -406,6 +420,10 @@ L.GPX = L.FeatureGroup.extend({
 
   _parse_trkseg: function(line, options, tag) {
     var el = line.getElementsByTagName(tag);
+    var kilometer_point_layers = [];
+    var mile_point_layers = [];
+    var _this = this;
+
     if (!el.length) return [];
 
     var coords = [];
@@ -479,6 +497,58 @@ L.GPX = L.FeatureGroup.extend({
       if (last != null) {
         this._info.length += this._dist3d(last, ll);
 
+        /*
+         * Add points to the line.
+         */
+        if (options.gpx_options.show_kilometer_point || options.gpx_options.show_mile_point) {
+          if (this._parse_current_kilometer != null) {
+            // Kilometer Point
+            if (options.gpx_options.show_kilometer_point) {
+              if ((parseInt(this._info.length/1000) - this._parse_current_kilometer) > options.gpx_options.kilometer_point_options.kilometer_point_interval-1) {
+                this._parse_current_kilometer = parseInt(this._info.length/1000);
+                var icon = L.divIcon({ className: 'kilometer_tooltip', html: this._parse_current_kilometer.toString(), iconSize: options.gpx_options.mile_point_options.kilometer_point_radius });
+                var marker = L.marker(ll, { icon: icon });
+                kilometer_point_layers.push(marker);
+              }
+            }
+            // Mile Point
+            if (options.gpx_options.show_mile_point) {
+              if ((parseInt(this.to_miles(this._info.length)/1000) - this._parse_current_mile) > options.gpx_options.mile_point_options.mile_interval-1) {
+                this._parse_current_mile = parseInt(this.to_miles(this._info.length)/1000);
+                var icon = L.divIcon({ className: 'mile_tooltip', html: this._parse_current_mile.toString(), iconSize: options.gpx_options.mile_point_options.mile_point_radius });
+                var marker = L.marker(ll, { icon: icon });
+                mile_point_layers.push(marker);
+              }
+            }
+          } else {
+            this._parse_current_kilometer = parseInt(this._info.length/1000);
+            this._parse_current_mile = parseInt(this._info.length/1000);
+
+            // Append style element for the tooltip of the points
+            var element = document.createElement('style');
+            document.head.appendChild(element);
+            var sheet = element.sheet;
+            var styles = '';
+            styles += '.kilometer_tooltip, .mile_tooltip {';
+            styles += 'font-size: 9px;';
+            styles += 'border: 1px solid #777;';
+            styles += 'border-radius: 10px;';
+            styles += 'text-align: center;';
+            styles += '}';
+            sheet.insertRule(styles, 0);
+            var styles_kilometer = '.kilometer_tooltip {';
+            styles_kilometer += 'color: ' + options.gpx_options.kilometer_point_options.kilometer_point_color_text + ';';
+            styles_kilometer += 'background: ' + options.gpx_options.kilometer_point_options.kilometer_point_color + ';';
+            styles_kilometer += '}';
+            sheet.insertRule(styles_kilometer, 0);
+            var styles_mile = '.mile_tooltip {';
+            styles_mile += 'color: ' + options.gpx_options.mile_point_options.mile_point_color_text + ';';
+            styles_mile += 'background: ' + options.gpx_options.mile_point_options.mile_point_color + ';';
+            styles_mile += '}';
+            sheet.insertRule(styles_mile, 0);
+          }
+        }
+
         var t = ll.meta.ele - last.meta.ele;
         if (t > 0) {
           this._info.elevation.gain += t;
@@ -547,6 +617,14 @@ L.GPX = L.FeatureGroup.extend({
       });
       this.fire('addpoint', { point: marker, point_type: 'label', element: markers[i].element });
       layers.push(marker);
+    }
+
+    if (kilometer_point_layers.length > 1) {
+       _this.addLayer(new L.FeatureGroup(kilometer_point_layers));
+    }
+
+    if (mile_point_layers.length > 1) {
+       _this.addLayer(new L.FeatureGroup(mile_point_layers));
     }
 
     return layers;


### PR DESCRIPTION
This is an alternative to my PR#72. It avoids the problem of the distance markers being overwritten by the track, by using a divIcon instead of CircleMarker (which is higher in the Z-order than the track).
The PR uses a few lines of code from the Leaflet-distance-marker plugin. I believe the Copyright notice permits that.
Please use whichever version you prefer.