### PR TITLE
Added error event when no layers can be parsed from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ new L.GPX(app.params.gpx_url, {
 }).on('loaded', function(e) {
   var gpx = e.target;
   map.fitToBounds(gpx.getBounds());
+}).on('error', function(e) {
+  console.log('Error loading file: ' + e.err);
 }).addTo(map);
 ```
 
@@ -310,6 +312,14 @@ contains the following properties:
 
 One use case for those events is for example to attach additional
 content or behavior to the markers that were generated (popups, etc).
+
+`error` events are fired when no layers of the type(s) specified in
+`options.gpx_options.parseElements` can be parsed out of the given
+file. For instance, `error` would be fired if a file with no waypoints
+was attempted to be loaded with `parseElements` set to `['waypoint']`.
+Each `error` event contains the following property:
+
+- `err`: a message with details about the error that occurred.
 
 ## Line styling
 

--- a/gpx.js
+++ b/gpx.js
@@ -274,7 +274,10 @@ L.GPX = L.FeatureGroup.extend({
     var _this = this;
     var cb = function(gpx, options) {
       var layers = _this._parse_gpx_data(gpx, options);
-      if (!layers) return;
+      if (!layers) {
+        _this.fire('error', { err: 'No parseable layers of type(s) ' + JSON.stringify(options.gpx_options.parseElements) });
+        return;
+      }
       _this.addLayer(layers);
       _this.fire('loaded', { layers: layers, element: gpx });
     }


### PR DESCRIPTION
I spent a while trying to figure out why a page I'd built wouldn't load with this plugin using certain GPX files. I discovered that it was because I was trying to get `waypoint` data only, and sometimes the files didn't have any waypoints.

I figured that issue would be a lot easier to debug if an `error` event fired when no layers of the specified type could be parsed out of the file.

Thanks!