### PR TITLE
Fire "error" when a file fails to load.

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -257,6 +257,7 @@ L.GPX = L.FeatureGroup.extend({
   _load_xml: function(url, cb, options, async) {
     if (async == undefined) async = this.options.async;
     if (options == undefined) options = this.options;
+    var _this = this;
 
     var req = new window.XMLHttpRequest();
     req.open('GET', url, async);
@@ -265,7 +266,11 @@ L.GPX = L.FeatureGroup.extend({
     } catch(e) {}
     req.onreadystatechange = function() {
       if (req.readyState != 4) return;
-      if(req.status == 200) cb(req.responseXML, options);
+      if(req.status == 200) {
+          cb(req.responseXML, options);
+      } else {
+         _this.fire('error', { err: 'Unable to retreive GPX: ' + req.status});
+      }
     };
     req.send(null);
   },


### PR DESCRIPTION
When a requested URL fails to load, there is no notification back from the GPX loader.  This is just a patch so that it fires off an error that includes the HTTP GET status.