### PR TITLE
ll.meta.ele can be null

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -486,7 +486,7 @@ L.GPX = L.FeatureGroup.extend({
         this._info.elevation.min = ll.meta.ele;
       }
 
-      this._info.elevation._points.push([this._info.length, ll.meta.ele]);
+      this._info.elevation._points.push([this._info.length, ll.meta.ele || 0]);
       this._info.duration.end = ll.meta.time;
 
       if (last != null) {


### PR DESCRIPTION
When `ll.meta.ele` is null (which is possible), problems are caused when calling `get_elevation_data`, specifically `return a.toFixed(2) + ' km, ' + b.toFixed(0) + ' m';`, there `b` cannot be null because `toFixed` cannot be called on null.