### PR TITLE
Bug fix if desc is null

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -423,7 +423,7 @@ L.GPX = L.FeatureGroup.extend({
           icon: symIcon,
           type: 'waypoint'
         });
-        marker.bindPopup("<b>" + name + "</b>" + (desc.length > 0 ? '<br>' + desc : '')).openPopup();
+        marker.bindPopup("<b>" + name + "</b>" + ((desc && desc.length > 0) ? '<br>' + desc : '')).openPopup();
         this.fire('addpoint', { point: marker, point_type: 'waypoint', element: el[i] });
         layers.push(marker);
       }


### PR DESCRIPTION
`var desc = descEl.length > 0 ? descEl[0].textContent : '';` in line 364 might initialize the variable desc with null. However, in line 426 this gets accessed and causes an invalid access.