### PR TITLE
Add speed information

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ so in the 'loaded' event handler, calling one of the following methods on the
 * `get_elevation_max()`: returns the highest elevation, in meters
 * `get_elevation_gain()`: returns the cumulative elevation gain, in meters
 * `get_elevation_loss()`: returns the cumulative elevation loss, in meters
+* `get_speed_max()`: returns the maximum speed in km per hour
 * `get_average_hr()`: returns the average heart rate (if available)
 * `get_average_cadence()`: returns the average cadence (if available)
 * `get_average_temp()`: returns the average of the temperature (if available)
@@ -106,6 +107,7 @@ at your disposal:
 * `get_elevation_max_imp()`: returns the highest elevation, in feet
 * `get_elevation_gain_imp()`: returns the cumulative elevation gain, in feet
 * `get_elevation_loss_imp()`: returns the cumulative elevation loss, in feet
+* `get_speed_max_imp()`: returns the maximum speed in miles per hour
 
 The reason why these methods return milliseconds is that you have at your
 disposal nice helper methods to format a duration in milliseconds into a cool
@@ -123,6 +125,7 @@ string:
 You can also get full elevation, heartrate, cadence and temperature data with:
 
 * `get_elevation_data()` and `get_elevation_data_imp()`
+* `get_speed_data` and `get_speed_data_imp()`
 * `get_heartrate_data()` and `get_heartrate_data_imp()`
 * `get_cadence_data()` and `get_cadence_data_imp()`
 * `get_temp_data()` and `get_temp_data_imp()`

--- a/gpx.js
+++ b/gpx.js
@@ -137,6 +137,8 @@ L.GPX = L.FeatureGroup.extend({
   to_ft:               function(v) { return v * 3.28084; },
   m_to_km:             function(v) { return v / 1000; },
   m_to_mi:             function(v) { return v / 1609.34; },
+  ms_to_kmh:           function(v) { return v * 3.6; },
+  ms_to_mih:           function(v) { return v / 1609.34 * 3600; },
 
   get_name:            function() { return this._info.name; },
   get_desc:            function() { return this._info.desc; },
@@ -181,6 +183,23 @@ L.GPX = L.FeatureGroup.extend({
   get_elevation_min:      function() { return this._info.elevation.min; },
   get_elevation_max_imp:  function() { return this.to_ft(this.get_elevation_max()); },
   get_elevation_min_imp:  function() { return this.to_ft(this.get_elevation_min()); },
+
+  get_speed_data:         function() {
+    var _this = this;
+    return this._info.speed._points.map(
+      function(p) { return _this._prepare_data_point(p, _this.m_to_km, _this.ms_to_kmh,
+        function(a, b) { return a.toFixed(2) + ' km, ' + b.toFixed(2) + ' km/h'; });
+      });
+  },
+  get_speed_data_imp: function() {
+    var _this = this;
+    return this._info.elevation._points.map(
+      function(p) { return _this._prepare_data_point(p, _this.m_to_mi, _this.ms_to_mih,
+        function(a, b) { return a.toFixed(2) + ' mi, ' + b.toFixed(2) + ' mi/h'; });
+      });
+  },
+  get_speed_max:          function() { return this.m_to_km(this._info.speed.max) * 3600; },
+  get_elevation_max_imp:  function() { return this.to_miles(this.get_speed_max()); },
 
   get_average_hr:         function() { return this._info.hr.avg; },
   get_average_temp:         function() { return this._info.atemp.avg; },
@@ -253,6 +272,7 @@ L.GPX = L.FeatureGroup.extend({
       name: null,
       length: 0.0,
       elevation: {gain: 0.0, loss: 0.0, max: 0.0, min: Infinity, _points: []},
+      speed : {max: 0.0, _points: []},
       hr: {avg: 0, _total: 0, _points: []},
       duration: {start: null, end: null, moving: 0, total: 0},
       atemp: {avg: 0, _total: 0, _points: []},

--- a/gpx.js
+++ b/gpx.js
@@ -449,7 +449,7 @@ L.GPX = L.FeatureGroup.extend({
       var _, ll = new L.LatLng(
         el[i].getAttribute('lat'),
         el[i].getAttribute('lon'));
-      ll.meta = { time: null, ele: null, hr: null, cad: null, atemp: null };
+      ll.meta = { time: null, ele: null, hr: null, cad: null, atemp: null, speed: null };
 
       _ = el[i].getElementsByTagName('time');
       if (_.length > 0) {
@@ -465,6 +465,15 @@ L.GPX = L.FeatureGroup.extend({
         // If the point doesn't have an <ele> tag, assume it has the same
         // elevation as the point before it (if it had one).
         ll.meta.ele = last.meta.ele;
+      }
+
+      _ = el[i].getElementsByTagName('speed');
+      if (_.length > 0) {
+        ll.meta.speed = parseFloat(_[0].textContent);
+      } else {
+        // If the point doesn't have an <speed> tag, assume it has the same
+        // speed as the point before it (if it had one).
+        ll.meta.speed = last.meta.speed;
       }
 
       _ = el[i].getElementsByTagName('name');
@@ -510,6 +519,13 @@ L.GPX = L.FeatureGroup.extend({
       }
 
       this._info.elevation._points.push([this._info.length, ll.meta.ele]);
+
+      if (ll.meta.speed > this._info.speed.max) {
+        this._info.speed.max = ll.meta.speed;
+      }
+
+      this._info.speed._points.push([this._info.length, ll.meta.speed]);
+
       this._info.duration.end = ll.meta.time;
 
       if (last != null) {


### PR DESCRIPTION
This PR adds the support for speed information either read directly from `<speed>` elements of the `gpx` file or computed from successive positions. Following the current API naming convention, the speed information along the track can be accessed via `get_speed_data` or `get_speed_data_imp` and the maximum speed via `get_speed_max` or `get_speed_max_imp`.