### PR TITLE
Add popupTemplate-option to marker_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ new L.GPX(app.params.gpx_url, {
 }).addTo(map);
 ```
 
+The content of the popup created for waypoints can be customised by setting `marker_options.popupTemplate` to a function returning the popup content, receiving name and description of the waypoint as arguments. The (simplified) default looks like
+
+```javascript
+marker_options.popupTemplate = function(name, desc) { return `<b>${name}</b> $desc` };
+```
+
 ## Custom markers
 
 You can also use your own icons/markers if you want to use custom

--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ new L.GPX(app.params.gpx_url, {
 }).addTo(map);
 ```
 
-The content of the popup created for waypoints can be customised by setting `marker_options.popupTemplate` to a function returning the popup content, receiving name and description of the waypoint as arguments. The (simplified) default looks like
+The content of the popup created for waypoints can be customised by setting
+`marker_options.popupTemplate` to a function returning the popup content,
+receiving name and description of the waypoint as arguments. The (simplified)
+default is defined as follows:
 
 ```javascript
 marker_options.popupTemplate = function(name, desc) { return `<b>${name}</b> $desc` };

--- a/gpx.js
+++ b/gpx.js
@@ -63,7 +63,8 @@ var _DEFAULT_MARKER_OPTS = {
   shadowSize: [50, 50],
   iconAnchor: [16, 45],
   shadowAnchor: [16, 47],
-  clickable: false
+  clickable: false,
+  popupTemplate: function(name, desc) { return `<b>${name}</b>${desc.length > 0 ? '<br>' : ''} ${desc}` }
 };
 var _DEFAULT_POLYLINE_OPTS = {
   color: 'blue'
@@ -443,7 +444,7 @@ L.GPX = L.FeatureGroup.extend({
           icon: symIcon,
           type: 'waypoint'
         });
-        marker.bindPopup("<b>" + name + "</b>" + (desc.length > 0 ? '<br>' + desc : '')).openPopup();
+        marker.bindPopup(options.marker_options.popupTemplate(name, desc)).openPopup();
         this.fire('addpoint', { point: marker, point_type: 'waypoint', element: el[i] });
         layers.push(marker);
       }


### PR DESCRIPTION
The default value retains the original behaviour, but opens up the
possibility to render the popup as wanted by a function passed in
the options.