### PR TITLE
multi-tracks gpx

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -140,6 +140,7 @@ L.GPX = L.FeatureGroup.extend({
   ms_to_kmh:           function(v) { return v * 3.6; },
   ms_to_mih:           function(v) { return v / 1609.34 * 3600; },
 
+  get_number_of_tracks:function() { return this._info.number_of_tracks; },
   get_name:            function() { return this._info.name; },
   get_desc:            function() { return this._info.desc; },
   get_author:          function() { return this._info.author; },
@@ -269,6 +270,7 @@ L.GPX = L.FeatureGroup.extend({
 
   _init_info: function() {
     this._info = {
+      number_of_tracks: 0,
       name: null,
       length: 0.0,
       elevation: {gain: 0.0, loss: 0.0, max: 0.0, min: Infinity, _points: []},
@@ -324,23 +326,6 @@ L.GPX = L.FeatureGroup.extend({
   _parse_gpx_data: function(xml, options) {
     var i, t, l, el, layers = [];
 
-    var name = xml.getElementsByTagName('name');
-    if (name.length > 0) {
-      this._info.name = name[0].textContent;
-    }
-    var desc = xml.getElementsByTagName('desc');
-    if (desc.length > 0) {
-      this._info.desc = desc[0].textContent;
-    }
-    var author = xml.getElementsByTagName('author');
-    if (author.length > 0) {
-      this._info.author = author[0].textContent;
-    }
-    var copyright = xml.getElementsByTagName('copyright');
-    if (copyright.length > 0) {
-      this._info.copyright = copyright[0].textContent;
-    }
-
     var parseElements = options.gpx_options.parseElements;
     if (parseElements.indexOf('route') > -1) {
       // routes are <rtept> tags inside <rte> sections
@@ -354,7 +339,28 @@ L.GPX = L.FeatureGroup.extend({
       // tracks are <trkpt> tags in one or more <trkseg> sections in each <trk>
       var tracks = xml.getElementsByTagName('trk');
       for (i = 0; i < tracks.length; i++) {
+       	if ((options.hasOwnProperty("trackNumber")) && (i != options.trackNumber))
+       		continue;
+        this._info.number_of_tracks++;
         var track = tracks[i];
+
+        var name = track.getElementsByTagName('name');
+        if (name.length > 0) {
+          this._info.name = name[0].textContent;
+        }
+        var desc = track.getElementsByTagName('desc');
+        if (desc.length > 0) {
+          this._info.desc = desc[0].textContent;
+        }
+        var author = track.getElementsByTagName('author');
+        if (author.length > 0) {
+          this._info.author = author[0].textContent;
+        }
+        var copyright = track.getElementsByTagName('copyright');
+        if (copyright.length > 0) {
+          this._info.copyright = copyright[0].textContent;
+        }
+
         var polyline_options = this._extract_styling(track);
 
         if (options.gpx_options.joinTrackSegments) {


### PR DESCRIPTION
As suggested by https://github.com/mpetazzoni/leaflet-gpx/issues/123, added a "trackNumber" option to return a single track, when the gpx file contains multiple ones. The name, desc etc are then returned from this track. Also added get_number_of_tracks() to count the tracks.

I am not a javascript expert, maybe there is a better way to go; but I used this like this:

```
var colors = ['#0000FF', '#FF00FF', '#25DB00', '#FF0000', '#00C0FF', '#FF7F00', '#A46129'];
new L.GPX(groupGpxURL, {async: true, marker_options: opts}).on('loaded', function(e) {
	var gpx = e.target;
	for (trackIdx=0; trackIdx<gpx.get_number_of_tracks(); trackIdx++) {
		var polyline_options = {
			color: colors[trackIdx % colors.length],
			opacity: 0.5,
			weight: 7,
			lineCap: 'round'
		};
		new L.GPX(groupGpxURL, {async: true, marker_options: opts, trackNumber: trackIdx, polyline_options: polyline_options}).on('loaded', function(e) {
			var gpxTrack = e.target;
			gpxTrack.addTo(map);
			layerControl.addOverlay(gpxTrack, gpxTrack.get_name());
		});
	}
});
```
