### PR TITLE
Bug fix, placed distance increment before assignment to points

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -511,6 +511,8 @@ L.GPX = L.FeatureGroup.extend({
         }
       }
 
+      this._info.length += dist_3d;
+
       _ = el[i].getElementsByTagNameNS('*', 'hr');
       if (_.length > 0) {
         ll.meta.hr = parseInt(_[0].textContent);
@@ -553,8 +555,6 @@ L.GPX = L.FeatureGroup.extend({
       if (time_diff < options.max_point_interval) {
         this._info.duration.moving += time_diff;
       }
-
-      this._info.length += dist_3d;
 
       if (ele_diff > 0) {
         this._info.elevation.gain += ele_diff;


### PR DESCRIPTION
One has to first increment the 3D distance before assigning it to the points. When you graph short gpx files you will directly see that the last distance is never incremented and that each distance value does not correspond to the correct elevation value. Placing the increment above assignments of _info.length corrects this issue.