### PR TITLE
Correct bug in get_polyline_options

### DIFF
--- a/gpx.js
+++ b/gpx.js
@@ -614,7 +614,7 @@ L.GPX = L.FeatureGroup.extend({
      * Handle backwards compatibility with polyline_options being provided as a single object.
      * In this situation, the provided style is expected to apply to all routes and tracks in the file.
      */
-    if (Array.isArray(polyline_options)) {
+    if (! Array.isArray(polyline_options)) {
       return polyline_options;
     }
     return polyline_options[i] || {};


### PR DESCRIPTION
The logic in the `if` got switched around. If `polyline_options` was not an array, it was attempting to access it like one. The result was that all user provided styling was ignored.