### PR TITLE
Add map height for a fully working min example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Usage is very simple:
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-gpx/2.1.2/gpx.min.js" defer></script>
-    <!-- ... -->
+    <style>
+      #map { height: 500px; }
+    </style>
   </head>
   <body>
     <div id="map"></div>


### PR DESCRIPTION
Otherwise it's blank, which was confusing for me initially. I had to go to leaflet's getting started page to find the info: https://leafletjs.com/examples/quick-start/

Tool is awesome and this is not a big deal, but adding here because it might help someone